### PR TITLE
Add post descriptions and enable robots.txt

### DIFF
--- a/content/posts/code-as-the-new-latin.md
+++ b/content/posts/code-as-the-new-latin.md
@@ -2,6 +2,7 @@
 title: "Code as the new Latin"
 date: 2011-12-11
 tags: []
+description: "Reflections on why coding literacy matters for everyone, inspired by David Mitchell's comparison of code to Latin."
 ---
 
 There's a thought provoking article by David Mitchell at

--- a/content/posts/email-in-emacs.md
+++ b/content/posts/email-in-emacs.md
@@ -2,6 +2,7 @@
 title: "Email in emacs"
 date: 2014-01-07
 tags: [emacs, email]
+description: "Setting up Notmuch with offlineimap and msmtp for fast, searchable email in Emacs on OS X."
 ---
 
 I genuinely dislike email, yet it's a necessary part of working and

--- a/content/posts/fixing-emacs-bindings-in-iterm2.md
+++ b/content/posts/fixing-emacs-bindings-in-iterm2.md
@@ -2,6 +2,7 @@
 title: "Fixing emacs bindings in iTerm2"
 date: 2013-02-22
 tags: [emacs]
+description: "How to fix Shift-Meta key combinations in Emacs running inside iTerm2 on OS X by mapping raw escape codes."
 ---
 
 I spend a decent amount of time in org-mode, using Emacs + iTerm2 on a

--- a/content/posts/growing-with-the-sparkleformation-registry.md
+++ b/content/posts/growing-with-the-sparkleformation-registry.md
@@ -2,6 +2,7 @@
 title: "Growing with the SparkleFormation registry"
 date: 2016-06-03
 tags: [aws, cloudformation]
+description: "Using SparkleFormation registries with arguments to build reusable, platform-aware CloudFormation init configurations."
 ---
 
 # Growing into SparkleFormation

--- a/content/posts/opscode-community-summit-day-one.md
+++ b/content/posts/opscode-community-summit-day-one.md
@@ -2,6 +2,7 @@
 title: "Opscode Community Summit - Day One"
 date: 2011-11-29
 tags: [opscode, chef]
+description: "Highlights from day one of the Opscode Community Summit, an unconference celebrating the Chef community."
 ---
 
 Opscode Summit day one has passed. I had to skip the sponsored dinner

--- a/content/posts/opscode-community-summit-day-two.md
+++ b/content/posts/opscode-community-summit-day-two.md
@@ -2,6 +2,7 @@
 title: "Opscode Community Summit - Day Two"
 date: 2011-11-30
 tags: [opscode, chef]
+description: "Day two of the Opscode Summit, featuring the big announcement of Hosted Chef moving from Ruby+NoSQL to Erlang+MySQL."
 ---
 
 The first historic Opscode Community Summit is officially over. See

--- a/content/posts/os-install-using-virtualbox-raw-disk-access.md
+++ b/content/posts/os-install-using-virtualbox-raw-disk-access.md
@@ -2,6 +2,7 @@
 title: "OS Install using VirtualBox raw disk access"
 date: 2014-01-24
 tags: []
+description: "Installing OpenBSD to an SD card from a MacBook Air using VirtualBox raw disk access."
 ---
 
 Recently I had a need to create a bootable sd card containing OpenBSD.

--- a/content/posts/sparkleformation-bedtime-story.md
+++ b/content/posts/sparkleformation-bedtime-story.md
@@ -2,6 +2,7 @@
 title: "SparkleFormation Bedtime Story"
 date: 2015-12-13
 tags: [aws, cloudformation]
+description: "A beginner's whirlwind tour of SparkleFormation, stumbling through VPC creation, AMI hunting and CloudFormation stack updates."
 ---
 
 # A very brief whirlwind tour of sparkles

--- a/content/posts/splitting-up-a-cookbook-repo.md
+++ b/content/posts/splitting-up-a-cookbook-repo.md
@@ -2,6 +2,7 @@
 title: "Splitting up a cookbook repo"
 date: 2011-12-15
 tags: [chef, git]
+description: "A script for splitting a monolithic Chef cookbooks repo into individual repos using git filter-branch and hub."
 ---
 
 It seems in the chef community lately there's a growing trend for

--- a/content/posts/this-i-want-to-remember.md
+++ b/content/posts/this-i-want-to-remember.md
@@ -2,6 +2,7 @@
 title: "This I want to remember"
 date: 2011-12-01
 tags: [chef]
+description: "Notes on the Opscode community effort to split the monolithic cookbooks repo into individual cookbook repos."
 ---
 
 One topic frequently tossed around at the recent Opscode summit was a

--- a/content/posts/update-cookbook-versions-with-an-awk-one-liner.md
+++ b/content/posts/update-cookbook-versions-with-an-awk-one-liner.md
@@ -2,6 +2,7 @@
 title: "Update cookbook_versions with an awk one-liner"
 date: 2012-03-23
 tags: [shell]
+description: "A quick awk one-liner to populate cookbook_versions in a Chef environment file."
 ---
 
 Sometimes it's the simplest things that remind me why I love the classic unix tools. Here's a quick way to fill in cookbook_versions for a chef environment using awk.

--- a/hugo.yml
+++ b/hugo.yml
@@ -2,6 +2,7 @@ baseURL: "https://webframp.com/"
 languageCode: en-us
 title: Webframp
 theme: PaperMod
+enableRobotsTXT: true
 pagination:
   pagerSize: 10
 


### PR DESCRIPTION
- Add `description` frontmatter to all 11 posts for SEO meta tags, Open Graph, and Twitter card previews
- Enable `robots.txt` generation in hugo.yml with sitemap reference

These descriptions now populate:
- `<meta name="description">` tags
- Open Graph `og:description`
- Twitter card `twitter:description`
- JSON-LD structured data
- Post subtitles in PaperMod theme