### PR TITLE
Add missing tags and default archetype

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,7 @@
+---
+title: "{{ replace .File.ContentBaseName `-` ` ` | title }}"
+date: {{ .Date }}
+tags: []
+description: ""
+draft: true
+---

--- a/content/posts/code-as-the-new-latin.md
+++ b/content/posts/code-as-the-new-latin.md
@@ -1,7 +1,7 @@
 ---
 title: "Code as the new Latin"
 date: 2011-12-11
-tags: []
+tags: [devops]
 description: "Reflections on why coding literacy matters for everyone, inspired by David Mitchell's comparison of code to Latin."
 ---
 

--- a/content/posts/os-install-using-virtualbox-raw-disk-access.md
+++ b/content/posts/os-install-using-virtualbox-raw-disk-access.md
@@ -1,7 +1,7 @@
 ---
 title: "OS Install using VirtualBox raw disk access"
 date: 2014-01-24
-tags: []
+tags: [openbsd]
 description: "Installing OpenBSD to an SD card from a MacBook Air using VirtualBox raw disk access."
 ---
 


### PR DESCRIPTION
- Tag 'Code as the new Latin' with devops
- Tag 'OS Install using VirtualBox raw disk access' with openbsd
- Add default archetype with draft: true for new posts