### PR TITLE
Add draft post: The Architect's Instinct

### DIFF
--- a/content/posts/architects-instinct.md
+++ b/content/posts/architects-instinct.md
@@ -1,0 +1,57 @@
+---
+title: "The Architect's Instinct"
+date: 2026-04-23T10:37:25-04:00
+tags: [devops, ai]
+description: "Mechanical friction is dissolving, but don't mistake easy for simple"
+draft: true
+---
+
+We are living through a strange professional silence. Many of us use AI every
+day while feeling a quiet guilt about it. We worry that by offloading the labor
+of coding, we are offloading our value as engineers. We reach for the tool
+because it works. Then we wonder what it means that we needed it. The discomfort
+is not about the technology. It is the sense that we are moving faster than we
+can think.
+
+The mechanical friction of engineering is dissolving. AI may seem like the
+ultimate “easy button,” and for some that feels like a victory. But in the world
+of software and its operation, easy and simple are not synonyms.[^1] 
+
+Easy is about friction and nearness. It describes the effort required to start.
+Simple is about structure. It describes how few parts are involved and how they relate.
+
+We have seen this pattern before. Every leap in speed, from C to Cloud, has pulled
+us into higher levels of abstraction. We gained immense power, but we moved
+further from the machine. In that distance, we sacrificed immediate
+comprehension. 
+
+Today, the speed of generation is outrunning our ability to understand. When we
+ship code we do not fully grasp, we aren't being lazy. We are simply being
+outpaced by our own tools. AI made the work easy. It did not make it simple.
+
+The danger isn’t just a bad pull request. It is the atrophy of instinct. If we
+stop thinking because generation is fast, we lose the ability to recognize
+structural danger before it fails in production. 
+
+But easy is not a dead end. It is a starting point. We will actually understand our systems
+more as AI writes them, provided we follow one rule: we must live in the system
+every day.
+
+We can dispatch the labor of coding to AI, but we own the architecture. To
+reclaim the spec is to reclaim our agency. When we define the plan in plain
+English, we aren't just giving instructions. We are exercising the judgment
+that the machine lacks.
+
+AI can handle the implementation; we own the intent. Writing the plan is the
+work. The plan is where simple lives. It is where we do our thinking. When we
+engage with the architecture daily, the AI becomes a mirror for our judgment. It
+does not replace our understanding. It forces us to become better architects of
+our own intentions.
+
+The software is not the work. The system that produces it is. Tools like
+[Swamp](https://swamp.club) are making this real. Be the person who builds that
+system. Not the approver of an LLM’s output. The architect of the machine that
+builds the machine.[^2]
+
+[^1]: Rich Hickey, [Simple Made Easy](https://www.youtube.com/watch?v=SxdOUGdseq4) (Strange Loop, 2011). [Transcript](https://github.com/matthiasn/talk-transcripts/blob/master/Hickey_Rich/SimpleMadeEasy.md).
+[^2]: Adam Jacob, [As We Build, So We Believe](https://www.adamhjk.com/blog/as-we-build-so-we-believe/).


### PR DESCRIPTION
Draft blog post exploring the easy vs. simple distinction in AI-assisted engineering.

Includes footnotes referencing Rich Hickey's Simple Made Easy and Adam Jacob's As We Build, So We Believe.

Preview should include the draft post via `hugo --buildDrafts`.