### PR TITLE
Restructure: The Mirror You Trained

### DIFF
--- a/content/posts/the-mirror-you-trained.md
+++ b/content/posts/the-mirror-you-trained.md
@@ -14,13 +14,13 @@ want to know with that level of precision.
 
 The same pattern repeats at every layer. Ask them to write a workflow DAG
 and they cannot specify which steps depend on which, because they have never
-separated their assumptions about sequence from the actual causal
-dependencies. Ask them to write a CEL query against versioned data and they
-cannot formulate the question, because they have never distinguished "what
-do I want to know" from "what does the system happen to show me."
+separated their assumptions about sequence from actual causal dependencies.
+A CEL query against versioned data exposes the same gap from a different
+angle: you must know the question before you can ask it, and most people
+have never distinguished "what do I want to know" from "what does the
+system happen to show me."
 
-This is not a tooling problem. This is a thinking problem that the tooling
-makes visible.
+The tooling is surfacing a thinking problem.
 
 I have watched this enough times to recognize the shape. The difficulty is
 never the syntax. It is always the same gap: the distance between what
@@ -28,11 +28,11 @@ someone vaguely intends and what they can state precisely enough for a
 deterministic system to act on. A typed schema does not accept vague intent.
 It requires you to know what you mean.
 
-An LLM has the same property, but without the structured feedback. When you
-prompt an LLM with vague intent, it returns vague output. When you prompt
-it with precise intent, clear constraints, explicit success criteria, it
-returns something you can evaluate against those criteria. The difference in
-output quality tracks directly to the difference in input precision.
+An LLM has the same property, but without the structured feedback. The
+difference in output quality tracks directly to the difference in input
+precision. Precise constraints and explicit success criteria produce output
+you can evaluate. Vague intent produces output nobody can evaluate, because
+there was never a stated standard to evaluate against.
 
 I owned an African Grey parrot for years. The bird was brilliant in ways
 that surprised people who had never lived with one. It learned my moods. It
@@ -45,9 +45,8 @@ entirely on the quality of what went in.
 
 If AI is the stochastic parrot that its critics claim, then the mirror it
 holds up reflects the thinking you feed it. When the output is generic and
-forgettable, that is a diagnostic. Not a diagnosis of the tool. A diagnosis
-of the input. Vague input, vague output. The mirror does not lie, and it
-does not flatter.
+forgettable, that is a diagnostic of the input. Vague input, vague output.
+The mirror does not lie, and it does not flatter.
 
 A programmer posted on Substack recently about the death of taste. His
 coworkers ship marketing copy through ChatGPT, the results are
@@ -83,10 +82,9 @@ think and articulate it clearly enough for another entity without your
 context to act on it.
 
 People are capable of far more precise thinking than their environment has
-ever required of them. The gap between what they can do and what they
-routinely do is enormous. The systems they move through every day do not
-exercise that capacity because those systems were never designed to. They
-were designed for throughput, not depth.
+ever required of them. The gap between capacity and routine practice is
+enormous, and it persists because every system in a knowledge worker's week
+optimizes for throughput, not depth.
 
 The LLM does not create the thinking gap. It makes the gap visible and
 consequential for the first time.
@@ -140,14 +138,9 @@ learned when those assumptions hit production. The agent asked the
 questions. You did the thinking. The data layer kept the record, and the
 record trained you.
 
-This is what the training environment looks like. Typed constraints that
-force explicit intent before execution. Versioned output that makes drift
-from intent observable over time. Structured review workflows where the
-evaluation criteria exist as data, not as a feeling in someone's gut.
-Feedback loops short enough that the connection between input quality and
-output quality remains visible. The feedback and versioning are automatic.
-The human part is the design: deciding what to model, what to observe, what
-conditions constitute success.
+The feedback and versioning are automatic. The human part is the design:
+deciding what to model, what to observe, what conditions constitute
+success.
 
 The mirror is already in the room. What matters now is what you build
 around it.

--- a/content/posts/the-mirror-you-trained.md
+++ b/content/posts/the-mirror-you-trained.md
@@ -5,72 +5,88 @@ tags: [ai, swamp, thinking, systems]
 description: "The LLM does not create the thinking gap. It makes the gap visible and consequential for the first time."
 ---
 
-A programmer posts on Substack about the death of taste. His coworkers are
-shipping marketing copy through ChatGPT and the results are indistinguishable
-from what they wrote before, and nobody notices, and this terrifies him. He
-watches people around him stop thinking about what they want to say and start
-accepting whatever comes back. The conclusion he reaches: AI is eroding the
-capacity for original thought.
+Hand someone a typed model in [swamp](https://swamp-club.com/) and ask them
+to define what data they want to capture. Watch what happens. The schema
+requires them to name the fields, specify the types, declare what
+constitutes a valid observation. Most people stall. Not because the tooling
+is hard. Because they have never been asked to articulate what they actually
+want to know with that level of precision.
+
+The same pattern repeats at every layer. Ask them to write a workflow DAG
+and they cannot specify which steps depend on which, because they have never
+separated their assumptions about sequence from the actual causal
+dependencies. Ask them to write a CEL query against versioned data and they
+cannot formulate the question, because they have never distinguished "what
+do I want to know" from "what does the system happen to show me."
+
+This is not a tooling problem. This is a thinking problem that the tooling
+makes visible.
+
+I have watched this enough times to recognize the shape. The difficulty is
+never the syntax. It is always the same gap: the distance between what
+someone vaguely intends and what they can state precisely enough for a
+deterministic system to act on. A typed schema does not accept vague intent.
+It requires you to know what you mean.
+
+An LLM has the same property, but without the structured feedback. When you
+prompt an LLM with vague intent, it returns vague output. When you prompt
+it with precise intent, clear constraints, explicit success criteria, it
+returns something you can evaluate against those criteria. The difference in
+output quality tracks directly to the difference in input precision.
+
+I owned an African Grey parrot for years. The bird was brilliant in ways
+that surprised people who had never lived with one. It learned my moods. It
+offered me objects at specific times that correlated with my emotional
+state. It echoed back phrases it had learned from me, and deployed them in
+exactly the right context to communicate what it needed. The phrases were
+mine. The deployment was the bird's intelligence. But the raw material was
+always what I had given it, and the quality of what came back depended
+entirely on the quality of what went in.
+
+If AI is the stochastic parrot that its critics claim, then the mirror it
+holds up reflects the thinking you feed it. When the output is generic and
+forgettable, that is a diagnostic. Not a diagnosis of the tool. A diagnosis
+of the input. Vague input, vague output. The mirror does not lie, and it
+does not flatter.
+
+A programmer posted on Substack recently about the death of taste. His
+coworkers ship marketing copy through ChatGPT, the results are
+indistinguishable from what they wrote before, nobody notices, and this
+terrifies him. He watches people accept whatever comes back without
+evaluating it against any stated intent.
 
 He is diagnosing a real symptom. He is mis-attributing the cause.
 
-The taste collapse he observes in marketing copy did not begin when the LLM
-arrived. It began when the organization spent fifteen years optimizing internal
-communication for skimmability. For TL;DR headers. For Slack-message attention
-spans. For quarterly review decks that nobody reads past slide three. The LLM
-walked into a room full of people who had already been trained to produce and
-consume language at the shallowest possible depth. It handed them a tool that
-operates at exactly that depth, faster. 
+The taste collapse he observes did not begin when the LLM arrived. It began
+when organizations spent fifteen years optimizing internal communication for
+skimmability. For TL;DR headers. For Slack-message attention spans. For
+quarterly review decks that nobody reads past slide three. The LLM walked
+into a room full of people who had already been trained to produce and
+consume language at the shallowest possible depth. It handed them a tool
+that operates at exactly that depth, faster.
 
-This is a systems observation, not a judgment about individuals. Deming spent
-forty years pointing at the same structure: when the system produces a
-consistent output, the system is the cause. Blaming the worker for the system's
-design is the oldest management failure in the industrial playbook. The
-programmer on Substack is doing a version of that. He sees his colleagues
-producing mediocre output with AI assistance and concludes they lack taste. What
-he is actually observing is an environment that never selected for taste in the
-first place.
+This is a systems observation, not a judgment about individuals. Deming
+spent forty years pointing at the same structure: when the system produces a
+consistent output, the system is the cause. The programmer on Substack sees
+his colleagues producing mediocre output with AI assistance and concludes
+they lack taste. What he is actually observing is an environment that never
+selected for taste in the first place.
 
 A typical knowledge worker moves through systems that never ask for
-precision. Work communication happens on Slack, optimized for speed and
-reaction time, not depth. Entertainment happens on streaming platforms that have
-redesigned their content for what the industry calls the "second screen"
-problem: viewers watch with a phone in hand, half-attending, so shows are
-rewritten with simpler dialog, more obvious emotional cues, and plot structures
-that survive 40% attention. Social media rewards the fastest emotional response,
-not the most considered one. None of these systems train the skill that
-good AI interaction requires: the ability to know precisely what you think
-and articulate it with enough clarity that another entity without access to
-your context can act on it accurately.
-
-I owned an African Grey parrot for years. The bird was brilliant in ways that
-surprised people who had never lived with one. It learned my moods. It offered
-me objects at specific times that correlated with my emotional state. It echoed
-back phrases it had learned from me, and deployed them in exactly the right
-context to communicate what it needed. The phrases were mine. The deployment was
-the bird's intelligence. But the raw material was always what I had given it,
-and the quality of what came back depended entirely on the quality of what went
-in.
-
-If AI is the stochastic parrot that its critics claim, then the mirror it holds
-up reflects the thinking you feed it. When the output is generic and forgettable,
-that is a diagnostic. Not a diagnosis of the tool. A diagnosis of the input.
-The person who cannot articulate what they want with precision gets
-imprecise results back. Vague input, vague output. The mirror does
-not lie, and it does not flatter.
-
-Most people have never been confronted with a system that reflects the
-quality of their thinking back at them this directly. A human collaborator
-fills gaps. They infer your intent from tone,
-from history, from shared context you never made explicit. They compensate for
-imprecision. The LLM does not compensate. It operates on what you gave it. When
-what you gave it was unclear, the output shows you exactly how unclear you were.
+precision. Slack optimizes for speed, not depth. Streaming platforms
+redesign their content for what the industry calls the "second screen"
+problem: shows rewritten with simpler dialog and obvious cues so distracted
+viewers will not miss the plot. Social media rewards the fastest emotional
+response, not the most considered one. None of these systems train the skill
+that good AI interaction requires: the ability to know precisely what you
+think and articulate it clearly enough for another entity without your
+context to act on it.
 
 People are capable of far more precise thinking than their environment has
-ever required of them. The gap between what they can do and what
-they routinely do is enormous. The systems they move through every day do not
-exercise that capacity because those systems were never designed to. They were
-designed for throughput, not depth.
+ever required of them. The gap between what they can do and what they
+routinely do is enormous. The systems they move through every day do not
+exercise that capacity because those systems were never designed to. They
+were designed for throughput, not depth.
 
 The LLM does not create the thinking gap. It makes the gap visible and
 consequential for the first time.
@@ -81,61 +97,57 @@ in individual character. Both miss what is actually available: build systems
 that close the gap.
 
 The thinking that produces good AI output is the same thinking that produces
-good engineering, good writing, good decision-making without AI. Clear intent.
-Precise articulation. Explicit constraints. Willingness to review output against
-intent and iterate when they diverge. These are skills, and skills respond to
-training environments.
+good engineering, good writing, good decision-making without AI. Clear
+intent. Precise articulation. Explicit constraints. Willingness to review
+output against intent and iterate when they diverge. These are skills, and
+skills respond to training environments.
 
-In [swamp](https://swamp-club.com/), this takes a concrete form. A typed model with a Zod schema forces
-you to articulate what data you want to capture before you capture it. A
-workflow DAG makes dependencies and conditions explicit. A CEL query against
-versioned data requires knowing the question before you ask it. None of
-these steps involve probability. They are
-deterministic structures that require clear human intent as input, and they
-produce verifiable, versioned, queryable output.
+In swamp, the training environment already exists. A typed model with a Zod
+schema forces you to articulate what data you want to capture before you
+capture it. A workflow DAG makes dependencies and conditions explicit. A CEL
+query against versioned data requires knowing the question before you ask
+it. None of these steps involve probability. They are deterministic
+structures that require clear human intent as input, and they produce
+verifiable, versioned, queryable output.
 
 The agent runs inside those structures. When the model method produces typed
-data that does not match what you expected, the schema tells you exactly where
-intent and outcome diverged. When the workflow step fails a condition, the DAG
-shows you which dependency produced the unexpected state. The system gives you
-feedback loops that the raw LLM interaction does not: structured, typed,
-versioned evidence of what your thinking produced when it hit reality. You can
-query the history. You can compare version three against version seven and see
-where your understanding shifted.
+data that does not match what you expected, the schema tells you exactly
+where intent and outcome diverged. When the workflow step fails a condition,
+the DAG shows you which dependency produced the unexpected state. The system
+gives you feedback loops that the raw LLM interaction does not: structured,
+typed, versioned evidence of what your thinking produced when it hit
+reality. You can query the history. You can compare version three against
+version seven and see where your understanding shifted.
 
-This is the environment that trains better thinking. Not a moral exhortation to
-think harder. Not a ban on the tools that reveal the gap. A system that
-produces legible feedback at the exact point where unclear intent meets
-structured execution. The feedback and versioning are automatic. The human
-part is the design:
-deciding what to model, what to observe, what conditions constitute
-success.
-
-The programmer watching his colleagues accept generic output is witnessing a
-feedback vacuum. They generate, they ship, nobody closes the loop. No one
+Compare this to the feedback vacuum the programmer on Substack is
+witnessing. His colleagues generate, ship, and never close the loop. No one
 stated intent precisely enough for drift to be measurable. They have a tool
-and no training environment for using it well. Compare this to a [code review](https://swamp.club/extensions/@webframp/gitlab-review)
-workflow built in swamp: the agent fetches a diff, produces a typed review
-draft, and stores it as versioned data. You revise it. The revision is a new
-version. When you look at version one against version four you can see where
-your criteria sharpened, where your understanding of what matters in a diff
-evolved. The loop closes because the system retains your thinking across
-iterations and shows you the trajectory.
+and no training environment for using it well. A
+[code review](https://swamp.club/extensions/@webframp/gitlab-review)
+workflow built in swamp is the opposite: the agent fetches a diff, produces
+a typed review draft, and stores it as versioned data. You revise it. The
+revision is a new version. When you look at version one against version four
+you can see where your criteria sharpened, where your understanding of what
+matters in a diff evolved. The loop closes because the system retains your
+thinking across iterations and shows you the trajectory.
 
-What would the training environment look like? Typed constraints that force
-explicit intent before execution. Versioned output that makes drift from intent
-observable over time. Structured review workflows where the evaluation criteria
-exist as data, not as a feeling in someone's gut. Feedback loops short enough
-that the connection between input quality and output quality remains visible.
+A [DDD guidance](https://swamp.club/extensions/@webframp/ddd-guidance)
+model does the same for domain understanding. It stores the results of
+discovery conversations as typed, versioned resources. Twenty versions of a
+context map show how your understanding of your own system deepened over
+months. Early versions capture assumptions. Later versions capture what you
+learned when those assumptions hit production. The agent asked the
+questions. You did the thinking. The data layer kept the record, and the
+record trained you.
 
-These are buildable systems. They exist today. In swamp, a [DDD guidance](https://swamp.club/extensions/@webframp/ddd-guidance)
-model stores the results of domain discovery conversations as typed,
-versioned resources. Twenty versions of a context map show how your
-understanding of your own system deepened over months. Early versions
-capture assumptions. Later versions capture what you learned when those
-assumptions hit production. The agent asked the questions. You did the
-thinking. The data layer kept the record, and the record trained you.
-Environments where those skills develop as a natural consequence of doing
-the work, not as a separate discipline that requires willpower.
+This is what the training environment looks like. Typed constraints that
+force explicit intent before execution. Versioned output that makes drift
+from intent observable over time. Structured review workflows where the
+evaluation criteria exist as data, not as a feeling in someone's gut.
+Feedback loops short enough that the connection between input quality and
+output quality remains visible. The feedback and versioning are automatic.
+The human part is the design: deciding what to model, what to observe, what
+conditions constitute success.
 
-The mirror is already in the room. What matters now is what you build around it.
+The mirror is already in the room. What matters now is what you build
+around it.


### PR DESCRIPTION
## Summary
- Inverts essay structure: opens from builder experience (watching people stall at typed schemas), not cultural commentary
- Swamp and agent-building observations establish the frame; Rickun, Deming, second-screen arrive as supporting evidence
- Addresses feedback that prior version read as generic cultural commentary with no builder voice

## Test plan
- [ ] Verify Hugo builds cleanly
- [ ] Read opening paragraphs cold and confirm they land as a builder's blog, not a philosophy essay

🤖 Generated with [Claude Code](https://claude.com/claude-code)